### PR TITLE
nproc without all flag returns 1 inside snakemake

### DIFF
--- a/src/mmlong2
+++ b/src/mmlong2
@@ -162,7 +162,7 @@ then
 fi
 
 # Check input for threads
-if [ $threads -gt $(nproc) ]
+if [ $threads -gt $(nproc --all) ]
 then
 	echo "ERROR: More CPU threads allocated than available ($(nproc)). Aborting..."
 	exit 1


### PR DESCRIPTION
When executing the script from snakemake, the output of nproc return 1, ending the script. Added --all flag to ensure all avalible threads are detected. 